### PR TITLE
tabby groups: Default 追加 + 未使用グループ削除

### DIFF
--- a/dot_config/tabby/config.yaml
+++ b/dot_config/tabby/config.yaml
@@ -8,116 +8,8 @@ overflow:
     mode: scroll
     indicator: ›
 groups:
-    - name: Dev
-      pattern: ^DEV\|
-      theme:
-        bg: '#1e1e2e'
-        fg: '#d4c4b0'
-        active_bg: '#B0201E'
-        active_fg: '#d4af37'
-        inactive_bg: ""
-        inactive_fg: ""
-        icon: ""
-        active_indicator_bg: ""
-      working_dir: ""
-    - name: Ops
-      pattern: ^OPS\|
-      theme:
-        bg: '#1e1e2e'
-        fg: '#d4c4b0'
-        active_bg: '#B0201E'
-        active_fg: '#d4af37'
-        inactive_bg: ""
-        inactive_fg: ""
-        icon: ""
-        active_indicator_bg: ""
-      working_dir: ""
-    - name: AI
-      pattern: ^AI\|
-      theme:
-        bg: '#1e1e2e'
-        fg: '#d4c4b0'
-        active_bg: '#B0201E'
-        active_fg: '#d4af37'
-        inactive_bg: ""
-        inactive_fg: ""
-        icon: "\U000F09D1"
-        active_indicator_bg: ""
-      working_dir: ""
-    - name: sidebar
-      pattern: ^sidebar\|
-      theme:
-        bg: '#1e1e2e'
-        fg: '#d4c4b0'
-        active_bg: '#B0201E'
-        active_fg: '#d4af37'
-        inactive_bg: ""
-        inactive_fg: ""
-        icon: ""
-        active_indicator_bg: ""
-      working_dir: ""
-    - name: SES
-      pattern: ^SES\|
-      theme:
-        bg: '#1e1e2e'
-        fg: '#d4c4b0'
-        active_bg: '#B0201E'
-        active_fg: '#d4af37'
-        inactive_bg: ""
-        inactive_fg: ""
-        icon: ""
-        active_indicator_bg: ""
-      working_dir: ""
-    - name: TestCheck
-      pattern: ^TestCheck\|
-      theme:
-        bg: '#1e1e2e'
-        fg: '#d4c4b0'
-        active_bg: '#B0201E'
-        active_fg: '#d4af37'
-        inactive_bg: ""
-        inactive_fg: ""
-        icon: ""
-        active_indicator_bg: ""
-      working_dir: ""
-    - name: newone
-      pattern: ^newone\|
-      theme:
-        bg: '#1e1e2e'
-        fg: '#d4c4b0'
-        active_bg: '#B0201E'
-        active_fg: '#d4af37'
-        inactive_bg: ""
-        inactive_fg: ""
-        icon: ""
-        active_indicator_bg: ""
-      working_dir: ""
-    - name: system
-      pattern: ^system\|
-      theme:
-        bg: '#1e1e2e'
-        fg: '#d4c4b0'
-        active_bg: '#B0201E'
-        active_fg: '#d4af37'
-        inactive_bg: ""
-        inactive_fg: ""
-        icon: •
-        active_indicator_bg: ""
-      working_dir: ""
-    - name: ses
-      pattern: ^ses\|
-      theme:
-        bg: '#1e1e2e'
-        fg: '#d4c4b0'
-        active_bg: '#B0201E'
-        active_fg: '#d4af37'
-        inactive_bg: ""
-        inactive_fg: ""
-        icon: ""
-        active_indicator_bg: ""
-      working_dir: ""
-    - name: Settings
-      pattern: ^Settings\|
+    - name: newses
+      pattern: ^newses\|
       theme:
         bg: '#1e1e2e'
         fg: '#cdd6f4'
@@ -129,7 +21,7 @@ groups:
         active_indicator_bg: ""
       working_dir: ""
     - name: Default
-      pattern: ".*"
+      pattern: .*
       theme:
         bg: '#1e1e2e'
         fg: '#d4c4b0'

--- a/dot_config/tabby/config.yaml
+++ b/dot_config/tabby/config.yaml
@@ -128,6 +128,18 @@ groups:
         icon: ""
         active_indicator_bg: ""
       working_dir: ""
+    - name: Default
+      pattern: ".*"
+      theme:
+        bg: '#1e1e2e'
+        fg: '#d4c4b0'
+        active_bg: '#B0201E'
+        active_fg: '#d4af37'
+        inactive_bg: ""
+        inactive_fg: ""
+        icon: ""
+        active_indicator_bg: ""
+      working_dir: ""
 bindings:
     toggle_sidebar: ""
     next_tab: ""


### PR DESCRIPTION
## Summary
- 個人設定 `~/.config/tabby/config.yaml` の `groups:` セクションを整理:
  - `Default` (pattern `.*`) catch-all グループを追加（未マッチ window のフォールバック先確保）
  - 未使用の空グループ 11 個（Dev / Ops / AI / sidebar / SES / TestCheck / newone / system / ses / Settings / new_ses）を削除
  - 実運用中の `newses` グループは残す

## Why
### Default 追加
`pkg/grouping/grouper.go` の `GroupWindowsWithOptions`:

```go
} else {
    // Group not found in config, fall back to Default
    if defaultGroup, ok := groupMap[\"Default\"]; ok {
        defaultGroup.Windows = append(defaultGroup.Windows, win)
    }
}
```

Default が `groupMap` に居ないと未マッチ window はどこにも積まれず、`show_empty_groups: false` の状況下でサイドバー中央が完全に空になる。bundled `dot_tmux/plugins/tabby/config.yaml` 側には元々 catch-all が入っていたが、個人設定 `dot_config/tabby/config.yaml` を新規追加した際に欠落していた。

### 未使用グループ削除
旧 dotfiles から持ち越された 11 グループは window が一切所属しておらず、`show_empty_groups: false` 運用ではサイドバーに何も表示されないノイズ。`tabby hook delete-group` でローカル yaml を整理し dotfiles にも反映。

## 残るグループ
- `Default` — catch-all
- `newses` — 実運用中

## Test plan
- [ ] chezmoi apply 後、サイドバーに表示されるグループが Default / newses だけになる
- [ ] グループプレフィックス無しの window が Default セクションに引き続き表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)