### PR TITLE
fix: tabby グループ n/d バインドを native hook に切り替え

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -113,9 +113,9 @@ bind -T group j   run-shell '~/.config/tabby/scripts/tabby-group-nav next' \; sw
 bind -T group k   run-shell '~/.config/tabby/scripts/tabby-group-nav prev' \; switch-client -T group
 
 # アクション (root に戻る)
-bind -T group n   command-prompt -p "New group name:" "run-shell '~/.config/tabby/scripts/tabby-new-group %%'"
+bind -T group n   command-prompt -p "New group name:" "run-shell '~/.tmux/plugins/tabby/bin/tabby hook new-group %% && ~/.tmux/plugins/tabby/bin/tabby new-window -group %%'"
 bind -T group r   command-prompt -p "New group name:" "run-shell '~/.config/tabby/scripts/tabby-rename-group %%'"
-bind -T group d   command-prompt -p "Delete group:" "confirm-before -p 'Delete group %%? (y/n)' \"run-shell '~/.config/tabby/scripts/tabby-hook delete-group %%'\" "
+bind -T group d   command-prompt -p "Delete group:" "confirm-before -p 'Delete group %%? (y/n)' \"run-shell '~/.tmux/plugins/tabby/bin/tabby hook delete-group %%'\" "
 
 # モード終了
 bind -T group Escape switch-client -T root


### PR DESCRIPTION
## Summary
- `dot_tmux.conf` の group モードバインド `n` (new) / `d` (delete) を、欠落していたラッパースクリプト呼び出しから tabby native の `tabby hook new-group` / `tabby hook delete-group` に変更
- 加えて `n` バインドは `tabby hook new-group <name>` の後に `tabby new-window -group <name>` を `&&` で連結し、グループ作成と同時にそのグループに所属する window を1枚生成

## Why
- スクリプト不在: `~/.config/tabby/scripts/tabby-new-group` 等は dotfiles に含まれず、`n` を押すと `... returned 127` で失敗していた。tabby 本体に同等の subcommand があるため直接叩けば動く
- 空グループの不可視性: `tabby hook new-group` は YAML にグループ定義を追加するだけで window を作らない。`show_empty_groups: false` 運用なので作成直後の空グループはサイドバー非表示になり「作ったのに見えない」状態になる。window を同時生成してこれを回避

## 残課題（このPRの対象外）
- `r` (rename): 旧グループ名を `#{@tabby_group}` から取る必要があり inline 化が煩雑。スクリプト参照のまま残す
- `h / j / k / l` (group-nav): native 等価コマンドが存在しない
- `after-new-window` hook の `auto-group-window.sh`: native 等価無し

これらが必要であればスクリプト群を `dot_config/tabby/scripts/` 配下に新規追加する別 PR で対応する想定。

## Test plan
- [ ] group mode 中に `n` → グループ名入力 → 設定 yaml に新グループが追加され、同時にそのグループ配下に window が1枚生成されサイドバーに即時表示される
- [ ] `d` → 既存グループ名入力 → 設定 yaml から削除される
- [ ] `r` は引き続き 127 で失敗する（未対応のため期待挙動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)